### PR TITLE
Eliminated the need to import an unmanaged library and stops IOExcept…

### DIFF
--- a/Shell/Program.cs
+++ b/Shell/Program.cs
@@ -11,21 +11,6 @@ namespace Shell
 
     class Program
     {
-        [DllImport("Kernel32")]
-        private static extern bool SetConsoleCtrlHandler(EventHandler handler, bool add);
-        private delegate bool EventHandler(CtrlType sig);
-        private static EventHandler _handler;
-
-        // Enumarate the API events.
-        private enum CtrlType
-        {
-            CTRL_C_EVENT = 0,
-            CTRL_BREAK_EVENT = 1,
-            CTRL_CLOSE_EVENT = 2,
-            CTRL_LOGOFF_EVENT = 5,
-            CTRL_SHUTDOWN_EVENT = 6
-        }
-
         // Deletes current directory temp file.
         private static void DeleteCDFIle()
         {
@@ -55,7 +40,7 @@ namespace Shell
                     if (file.EndsWith("cDir.t") && file.Contains(item))
                     {
                         FileInfo fileInfo = new FileInfo(file);
-                        File.Delete(fileInfo.FullName); 
+                        File.Delete(fileInfo.FullName);
                     }
                 }
             }
@@ -64,38 +49,14 @@ namespace Shell
                 File.Delete(GlobalVariables.currentDirectory);
         }
 
-        // Delete the current directory file on any of the events are triggered
-        private static bool Handler(CtrlType signal)
-        {
-            switch (signal)
-            {
-                case CtrlType.CTRL_LOGOFF_EVENT:
-                    DeleteCDFIle();
-                    Environment.Exit(0);
-                    return false;
-                case CtrlType.CTRL_SHUTDOWN_EVENT:
-                    DeleteCDFIle();
-                    Environment.Exit(0);
-                    return false;
-                case CtrlType.CTRL_BREAK_EVENT:
-                    DeleteCDFIle();
-                    Environment.Exit(0);
-                    return false;
-                case CtrlType.CTRL_CLOSE_EVENT:
-                    DeleteCDFIle();
-                    Environment.Exit(0);
-                    return false;
-                default:
-                    return false;
-            }
-        }
-
         static void Main(string[] args)
         {
+            /* Eliminates the need to import an unmanaged library and stops IOException error
+               when closing xTerminal from the title bar. */
+            AppDomain.CurrentDomain.ProcessExit += (s, e) => DeleteCDFIle();
+
             // confgure console
             Console.OutputEncoding = System.Text.Encoding.UTF8;//set utf8 encoding (for support Russian letters)
-            _handler += new EventHandler(Handler);
-            SetConsoleCtrlHandler(_handler, true); // New event for listening on close console event.
             var shell = new Shell();
             shell.Run(args);//Running the shell
         }


### PR DESCRIPTION
Eliminated the need to import an unmanaged library and stops IOException error when closing xTerminal from the title bar